### PR TITLE
feat: Select bookmark when in private Network

### DIFF
--- a/src/modules/content.go
+++ b/src/modules/content.go
@@ -30,8 +30,8 @@ type ColumnData struct {
 type BookmarkData struct {
 	Name string `yaml:"name"`
 	Url  string `yaml:"url"`
-
 	Icon string `yaml:"icon"`
+	IsLocal bool `yaml:"isLocal"`
 }
 
 func LoadContent() ContentData {


### PR DESCRIPTION
This adds a new property to BookmarkData struct indicating which bookmark should be listed only when the user is on a local Network meaning that he comes from VPN or on the same network. This do not check spoofing or that kind of stuff as I don't know how to do that here

Also this implies using a trusted reverse proxy etc to trust headers.

I'm not a really satisfied with the process as now we load data every time we it the path.